### PR TITLE
ユーザー名がGuestの時、匿名認証ではなくゲスト認証を用いる

### DIFF
--- a/app/src/main/java/src/comitton/common/FileAccess.java
+++ b/app/src/main/java/src/comitton/common/FileAccess.java
@@ -138,14 +138,16 @@ public class FileAccess {
 			smbAuth = new NtlmPasswordAuthenticator(domain, user, pass);
 			context = SingletonContext.getInstance().withCredentials(smbAuth);
 
-		} else if (user != null && user.length() != 0) {
+		} else if (user != null && user.length() != 0 && !user.equalsIgnoreCase("guest")) {
 			smbAuth = new NtlmPasswordAuthenticator(user, pass);
 			context = SingletonContext.getInstance().withCredentials(smbAuth);
 
+		} else if (user.equalsIgnoreCase("guest")) {
+			// Guest認証を期待するWindows共有の接続向け
+			context = SingletonContext.getInstance().withGuestCrendentials();
 		} else {
 			// Connect with anonymous mode
 			context = SingletonContext.getInstance().withAnonymousCredentials();
-//			context = SingletonContext.getInstance().withGuestCrendentials();
 		}
 
 		sfile = new SmbFile(url, context);


### PR DESCRIPTION
#2 
サーバー設定のユーザー名がguestの場合は、ユーザー認証では無くゲスト認証を行う様に修正。
提案いただいた通り、ユーザー未指定時の匿名認証と使い分けが可能です。
Windows共有でGuest認証を期待するサーバーを想定しています。