### PR TITLE
ジェスチャーナビゲーションと長押しメニューの競合解消、他

### DIFF
--- a/app/src/main/java/src/comitton/activity/FileSelectActivity.java
+++ b/app/src/main/java/src/comitton/activity/FileSelectActivity.java
@@ -942,6 +942,7 @@ public class FileSelectActivity extends Activity implements OnTouchListener, Lis
 		if (event.getAction() == KeyEvent.ACTION_DOWN) {
 			switch (keycode) {
 				case KeyEvent.KEYCODE_ENTER:
+				case KeyEvent.KEYCODE_DPAD_CENTER:
 					if (mEnterDown == false) {
 						mListScreenView.moveCursor(keycode, true);
 						mEnterDown = true;
@@ -1072,6 +1073,7 @@ public class FileSelectActivity extends Activity implements OnTouchListener, Lis
 					}
 					break;
 				case KeyEvent.KEYCODE_ENTER:
+				case KeyEvent.KEYCODE_DPAD_CENTER:
 					if (mEnterDown == true) {
 						mListScreenView.moveCursor(keycode, false);
 					}

--- a/app/src/main/java/src/comitton/activity/FileSelectActivity.java
+++ b/app/src/main/java/src/comitton/activity/FileSelectActivity.java
@@ -972,6 +972,20 @@ public class FileSelectActivity extends Activity implements OnTouchListener, Lis
 						switchFileList(); // ファイルリストをアクティブ化
 						return true;
 					}
+
+					// ジェスチャーナビゲーションのBack操作中に長押し判定が発生していた場合にキャンセルする
+					if (mTouchArea == ListScreenView.AREATYPE_FILELIST) {
+						mListScreenView.mFileListArea.cancelOperation();
+					} else if (mTouchArea == ListScreenView.AREATYPE_DIRLIST) {
+						mListScreenView.mDirListArea.cancelOperation();
+					} else if (mTouchArea == ListScreenView.AREATYPE_SERVERLIST) {
+						mListScreenView.mServerListArea.cancelOperation();
+					} else if (mTouchArea == ListScreenView.AREATYPE_FAVOLIST) {
+						mListScreenView.mFavoListArea.cancelOperation();
+					} else if (mTouchArea == ListScreenView.AREATYPE_HISTLIST) {
+						mListScreenView.mHistListArea.cancelOperation();
+					}
+
 					if (mBackMode == BACKMODE_EXIT) {
 						checkExitTimer();
 						return true;

--- a/app/src/main/java/src/comitton/activity/ImageActivity.java
+++ b/app/src/main/java/src/comitton/activity/ImageActivity.java
@@ -328,6 +328,7 @@ public class ImageActivity extends Activity implements OnTouchListener, Handler.
 	private boolean mIsConfSave;
 	private boolean mScrlNext = false; // スクロールで前後のページへ移動
 	private boolean mViewNext = false; // 次のページを表示
+	private boolean mNextFilter = true;
 
 	private String mCharset;
 
@@ -1804,7 +1805,7 @@ public class ImageActivity extends Activity implements OnTouchListener, Handler.
 	private void setViewConfig() {
 		if (mImageView != null) {
 			mImageView.setConfig(this, mMgnColor, mCenColor, mTopColor1, mViewPoint, mMargin, mCenter, mShadow, mZoomType, mPageWay, mScrlWay, mScrlRngW, mScrlRngH, mPrevRev, mNoExpand, mFitDual,
-					mCMargin, mCShadow, mPseLand, mEffect, mScrlNext, mViewNext);
+					mCMargin, mCShadow, mPseLand, mEffect, mScrlNext, mViewNext, mNextFilter);
 			mImageView.setLoupeConfig( mLoupeSize );	// ルーペサイズの設定
 		}
 		if (mGuideView != null) {
@@ -3901,6 +3902,7 @@ public class ImageActivity extends Activity implements OnTouchListener, Handler.
 
 			mScrlNext = SetImageActivity.getScrlNext(sharedPreferences); // スクロールで次のページへ移動
 			mViewNext = SetImageActivity.getViewNext(sharedPreferences); // 次のページを表示
+			mNextFilter = SetImageActivity.getNextFilter(sharedPreferences);
 
 			mRotateBtn = DEF.RotateBtnList[SetCommonActivity.getRotateBtn(sharedPreferences)];
 

--- a/app/src/main/java/src/comitton/activity/ImageActivity.java
+++ b/app/src/main/java/src/comitton/activity/ImageActivity.java
@@ -329,6 +329,7 @@ public class ImageActivity extends Activity implements OnTouchListener, Handler.
 	private boolean mScrlNext = false; // スクロールで前後のページへ移動
 	private boolean mViewNext = false; // 次のページを表示
 	private boolean mNextFilter = true;
+	private boolean mChgPageKey = false;
 
 	private String mCharset;
 
@@ -931,7 +932,8 @@ public class ImageActivity extends Activity implements OnTouchListener, Handler.
 				case KeyEvent.KEYCODE_DPAD_RIGHT:
 				case KeyEvent.KEYCODE_DPAD_LEFT: {
 					// カーソル左右でページ遷移
-					if ((code == KeyEvent.KEYCODE_DPAD_RIGHT && mPageWay == DEF.PAGEWAY_RIGHT) || (code == KeyEvent.KEYCODE_DPAD_LEFT && mPageWay != DEF.PAGEWAY_RIGHT)) {
+					if ((code == (!mChgPageKey ? KeyEvent.KEYCODE_DPAD_RIGHT : KeyEvent.KEYCODE_DPAD_LEFT) && mPageWay == DEF.PAGEWAY_RIGHT) ||
+						(code == (!mChgPageKey ? KeyEvent.KEYCODE_DPAD_LEFT : KeyEvent.KEYCODE_DPAD_RIGHT) && mPageWay != DEF.PAGEWAY_RIGHT)) {
 						// 次ページへ
 						nextPage();
 					}
@@ -3873,6 +3875,7 @@ public class ImageActivity extends Activity implements OnTouchListener, Handler.
 			mVolKeyMode = SetImageText.getVolKey(sharedPreferences); // 音量キー操作
 			mTapPattern = SetImageText.getTapPattern(sharedPreferences); // タップパターン
 			mTapRate = SetImageText.getTapRate(sharedPreferences); // タップの比率
+			mChgPageKey = SetImageText.getChgPageKey(sharedPreferences); // 左右キー操作入れ替え
 
 			mPnumDisp = SetImageActivity.getPnumDisp(sharedPreferences); // ページ表示有無
 			mPnumFormat = SetImageActivity.getPnumFormat(sharedPreferences); // ページ表示書式
@@ -3902,7 +3905,7 @@ public class ImageActivity extends Activity implements OnTouchListener, Handler.
 
 			mScrlNext = SetImageActivity.getScrlNext(sharedPreferences); // スクロールで次のページへ移動
 			mViewNext = SetImageActivity.getViewNext(sharedPreferences); // 次のページを表示
-			mNextFilter = SetImageActivity.getNextFilter(sharedPreferences);
+			mNextFilter = SetImageActivity.getNextFilter(sharedPreferences); // 次のページのエフェクト表示
 
 			mRotateBtn = DEF.RotateBtnList[SetCommonActivity.getRotateBtn(sharedPreferences)];
 

--- a/app/src/main/java/src/comitton/activity/TextActivity.java
+++ b/app/src/main/java/src/comitton/activity/TextActivity.java
@@ -192,6 +192,7 @@ public class TextActivity extends Activity implements OnTouchListener, Handler.C
 	private boolean mNotice;
 	private boolean mNoSleep;
 	private boolean mChgPage;
+	private boolean mChgPageKey;
 	private boolean mChgFlick;
 	private boolean mConfirmBack;
 	private boolean mCMargin;
@@ -726,15 +727,24 @@ public class TextActivity extends Activity implements OnTouchListener, Handler.C
 			switch (code) {
 				case KeyEvent.KEYCODE_DPAD_RIGHT:
 				{
-					// 次ページへ
-					nextPage();
+					if (mChgPageKey) {
+						// 前ページへ
+						prevPage();
+					} else {
+						// 次ページへ
+						nextPage();
+					}
 					break;
 				}
 				case KeyEvent.KEYCODE_DPAD_LEFT:
 				{
-					// 前ページへ
-					prevPage();
-					break;
+					if (mChgPageKey) {
+						// 次ページへ
+						nextPage();
+					} else {
+						// 前ページへ
+						prevPage();
+					}
 				}
 				case KeyEvent.KEYCODE_MENU:
 					// 独自メニュー表示
@@ -2381,6 +2391,7 @@ public class TextActivity extends Activity implements OnTouchListener, Handler.C
 		mTopColor2 = 0x40000000 | (mTopColor1 & 0x00FFFFFF);
 
 		mChgPage = SetImageText.getChgPage(sharedPreferences);
+		mChgPageKey = SetImageText.getChgPageKey(sharedPreferences);
 		mChgFlick = SetImageText.getChgFlick(sharedPreferences);
 		mLastMsg = SetImageText.getLastPage(sharedPreferences);
 		// mSavePage = false;// SetImageText.getSavePage(sharedPreferences);

--- a/app/src/main/java/src/comitton/common/DEF.java
+++ b/app/src/main/java/src/comitton/common/DEF.java
@@ -361,6 +361,7 @@ public class DEF {
 	public static final String KEY_SCRLNEXT = "ScrollNext";
 	public static final String KEY_VIEWNEXT = "ViewNextPage";
 	public static final String KEY_NEXTFILTER = "NextPageFilter";
+	public static final String KEY_CHGPAGEKEY = "ChgPageKey";
 
 	public static final String KEY_SHOWTOOLBAR = "ShowToolbar";
 	public static final String KEY_SHOWSELECTOR = "ShowSelector";
@@ -447,6 +448,7 @@ public class DEF {
 	public static final int DEFAULT_TAPRATE = 4; // 50% : 50%
 	public static final boolean DEFAULT_CHGPAGE = true; // タップ操作の入替え:YES(縦書き、漫画)
 	public static final boolean DEFAULT_PREVREV = true; // 前ページに戻った時に逆から表示
+	public static final boolean DEFAULT_CHGPAGEKEY = false; // 左右キー操作の入替え
 
 	public static final boolean DEFAULT_PNUMDISP = false; // ページ番号表示しない
 	public static final int DEFAULT_PNUMFORMAT = 0; // page / total

--- a/app/src/main/java/src/comitton/common/DEF.java
+++ b/app/src/main/java/src/comitton/common/DEF.java
@@ -360,6 +360,7 @@ public class DEF {
 	public static final String KEY_LOUPESIZE = "LoupeSize";
 	public static final String KEY_SCRLNEXT = "ScrollNext";
 	public static final String KEY_VIEWNEXT = "ViewNextPage";
+	public static final String KEY_NEXTFILTER = "NextPageFilter";
 
 	public static final String KEY_SHOWTOOLBAR = "ShowToolbar";
 	public static final String KEY_SHOWSELECTOR = "ShowSelector";

--- a/app/src/main/java/src/comitton/config/SetImageActivity.java
+++ b/app/src/main/java/src/comitton/config/SetImageActivity.java
@@ -554,6 +554,12 @@ public class SetImageActivity extends PreferenceActivity implements OnSharedPref
 		return flag;
 	}
 
+	public static boolean getNextFilter(SharedPreferences sharedPreferences){
+		boolean flag;
+		flag =  DEF.getBoolean(sharedPreferences, DEF.KEY_NEXTFILTER, true);
+		return flag;
+	}
+
 	//	public static boolean getEffect(SharedPreferences sharedPreferences){
 //		boolean flag;
 //		flag =  DEF.getBoolean(sharedPreferences, DEF.KEY_EFFECT, true);

--- a/app/src/main/java/src/comitton/config/SetImageText.java
+++ b/app/src/main/java/src/comitton/config/SetImageText.java
@@ -182,4 +182,10 @@ public class SetImageText {
 		int val = getTxPageSelect(sharedPreferences);
 		return res.getString(PageSelectName[val]);
 	}
+
+	public static boolean getChgPageKey(SharedPreferences sharedPreferences){
+		boolean flag;
+		flag =  DEF.getBoolean(sharedPreferences, DEF.KEY_CHGPAGEKEY, DEF.DEFAULT_CHGPAGEKEY);
+		return flag;
+	}
 }

--- a/app/src/main/java/src/comitton/view/image/MyImageView.java
+++ b/app/src/main/java/src/comitton/view/image/MyImageView.java
@@ -70,6 +70,7 @@ public class MyImageView extends SurfaceView implements SurfaceHolder.Callback, 
 	private boolean mScrlNext  = false;
 	private boolean mScrlNextStop = false;
 	private boolean mViewNext  = false;
+	private boolean mNextFilter = true;
 
 	private int mDispWidth  = 0;
 	private int mDispHeight = 0;
@@ -780,7 +781,8 @@ public class MyImageView extends SurfaceView implements SurfaceHolder.Callback, 
 					}
 				}
 				// 「スクロールで前後のページへ移動」の設定が有効かつ、スクロール量超過していないなら前後のページにグラデーションを重ねる
-				else if ((mScrlNext && !mScrlNextStop) && effect == 3 && mOverScrollX == 0 && mViewNext) {
+				// グラデーションOFFの時は表示しない
+				else if ((mScrlNext && !mScrlNextStop) && effect == 3 && mOverScrollX == 0 && mViewNext && mNextFilter) {
 					if (pseLand == false) {
 						// 横持ち
 						dl = (int) drawLeft;
@@ -987,7 +989,7 @@ public class MyImageView extends SurfaceView implements SurfaceHolder.Callback, 
 	}
 
 	// 余白色を設定
-	public void setConfig(ImageActivity parent, int mclr, int cclr, int gclr, int vp, int mgn, int cen, int sdw, int zom, int way, int sway, int srngw, int srngh, boolean pr, boolean ne, boolean fit, boolean cmgn, boolean csdw, boolean psel, int effect, boolean scrlNext, boolean viewNext){
+	public void setConfig(ImageActivity parent, int mclr, int cclr, int gclr, int vp, int mgn, int cen, int sdw, int zom, int way, int sway, int srngw, int srngh, boolean pr, boolean ne, boolean fit, boolean cmgn, boolean csdw, boolean psel, int effect, boolean scrlNext, boolean viewNext, boolean nextFilter){
 		mParentAct = parent;
 		mMgnColor  = mclr;
 		mCenColor  = cclr;
@@ -1020,6 +1022,7 @@ public class MyImageView extends SurfaceView implements SurfaceHolder.Callback, 
 		mEffect = effect;
 		mScrlNext = scrlNext;
 		mViewNext = viewNext;
+		mNextFilter = nextFilter;
 	}
 
 	public void setLoupeConfig( int size ) {

--- a/app/src/main/java/src/comitton/view/list/ListArea.java
+++ b/app/src/main/java/src/comitton/view/list/ListArea.java
@@ -788,7 +788,7 @@ public class ListArea implements Handler.Callback, ScrollMoveListener {
 		doOperation(true);
 		updateBottomRowPos();
 
-		if (mCursorDisp == true && keycode == KeyEvent.KEYCODE_ENTER) {
+		if (mCursorDisp == true && keycode == KeyEvent.KEYCODE_ENTER || keycode == KeyEvent.KEYCODE_DPAD_CENTER) {
 			// 改行はカーソル移動とは分けて処理
 			int index = mCursorPosY * mColumnNum + mCursorPosX; 
 			if (isDown) {

--- a/app/src/main/res/xml-ja/image.xml
+++ b/app/src/main/res/xml-ja/image.xml
@@ -250,6 +250,11 @@
             android:key="PageSelect"
             android:summary="dummy"
             android:title="ページ選択方法" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="ChgPageKey"
+            android:summary="チェックにより表紙方向キー(右表紙なら右キー)が前ページの移動になります"
+            android:title="左右キー操作の入替え＊" />
     </PreferenceCategory>
     <PreferenceCategory android:title="オンラインヘルプ" >
         <PreferenceScreen

--- a/app/src/main/res/xml-ja/image.xml
+++ b/app/src/main/res/xml-ja/image.xml
@@ -237,6 +237,11 @@
             android:key="ViewNextPage"
             android:summary="左右に表示領域が余っているときに次のページを表示する"
             android:title="次のページを表示" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="NextPageFilter"
+            android:summary="次のページを表示する時、グラデーションを表示する"
+            android:title="グラデーションを表示" />
         <ListPreference
             android:defaultValue="2"
             android:dialogTitle="ページ選択方法"

--- a/app/src/main/res/xml-ja/text.xml
+++ b/app/src/main/res/xml-ja/text.xml
@@ -185,6 +185,11 @@
             android:key="txPageSelect"
             android:summary="dummy"
             android:title="ページ選択方法" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="ChgPageKey"
+            android:summary="チェックにより右キーが前ページの移動になります"
+            android:title="左右キー操作の入替え＊" />
     </PreferenceCategory>
     <PreferenceCategory android:title="サイズ設定" >
         <src.comitton.config.TextFontTopSeekbar

--- a/app/src/main/res/xml/image.xml
+++ b/app/src/main/res/xml/image.xml
@@ -250,6 +250,11 @@
             android:key="PageSelect"
             android:summary="dummy"
             android:title="Page select operation(*)" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="ChgPageKey"
+            android:summary="When checked, Key to cover direction(if left cover then left key) will move to the previous page."
+            android:title="Swap the LR key operation(*)" />
     </PreferenceCategory>
     <PreferenceCategory android:title="Online Help" >
         <PreferenceScreen

--- a/app/src/main/res/xml/image.xml
+++ b/app/src/main/res/xml/image.xml
@@ -237,6 +237,11 @@
             android:key="ViewNextPage"
             android:summary="Display the next page when there is free display area to the side"
             android:title="Display next pages" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="NextPageFilter"
+            android:summary="Show gradation when displaying the next page"
+            android:title="Show gradation" />
         <ListPreference
             android:defaultValue="2"
             android:dialogTitle="Page select operation"

--- a/app/src/main/res/xml/text.xml
+++ b/app/src/main/res/xml/text.xml
@@ -185,6 +185,11 @@
             android:key="txPageSelect"
             android:summary="dummy"
             android:title="Page select operation(*)" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="ChgPageKey"
+            android:summary="When checked, right key will move to the previous page."
+            android:title="Swap the LR key operation(*)" />
     </PreferenceCategory>
     <PreferenceCategory android:title="Size Settings" >
         <src.comitton.config.TextFontTopSeekbar


### PR DESCRIPTION
## 変更内容

* ジェスチャーナビゲーションでBack操作を行った際、長押しメニューをキャンセルする
ケスチャーナビゲーションがタッチ操作から始まり、キー入力イベントに変化するため、タッチ系処理での長押しタイマーキャンセルが呼び出されていなかったため。

* グラデーションを表示をOFFにすることで、次のページを表示がONで条件を満たした時に表示される次のページに掛かるエフェクト（グラデーション）を表示しない
NxDの頃から気にするレスを見かけていたため。
対処出来たので設定切替式で追加してみました。

* 左右キー操作の入れ替えで、キー操作による前後ページへの移動を逆にする
右表紙でも左キーで次ページの操作で読みたかったため追加しました。

* DPADのセンターキーでEnterキーと同等の操作ができる
リモコンでの操作で読みたかったため追加しました。


よろしければご検討ください。